### PR TITLE
Azure AD app Name matching + Default AppControlMergeFile settings

### DIFF
--- a/V3/App-RegistrationDeployment.ps1
+++ b/V3/App-RegistrationDeployment.ps1
@@ -442,6 +442,7 @@ Else {
 #endregion 
 If (-not($ResourceGroup)) {$ResourceGroup = $DeploymentName}
 If (-not($AppServicePlan)) {$AppServicePlan = $DeploymentName}
+If (-not($AppControlMergeFile)) {$AppControlMergeFile = "App.AX.WS.xml?{ax365api1}=true;{UseDebugLog}=false;{Lines.RemoveOrginal}=true;{Lines.ChangeType}=true;{ForwardTo}=true;{ForwardTo.NoPrevious}=true;{Lang.All}=true;{Lines.UseLineTemplates}=true;{Lines.UseAsyncValidation}=true;{Labs.Vue.InAppSiteConfiguration}=true;"}
 <#If(-not(Get-AzResourceGroup -Name $ResourceGroup -ErrorAction SilentlyContinue)) {
     Write-Output ""
     Write-Output "--------------------------------------------------------------------------------"

--- a/V3/App-RegistrationDeployment.ps1
+++ b/V3/App-RegistrationDeployment.ps1
@@ -541,7 +541,7 @@ If(($AzAadApp = az ad app list --display-name $DeploymentName) -eq "[]") {
     Write-Output "Found existing app, updating..."
     $AzAadApp = $AzAadApp | ConvertFrom-Json
     $error.clear()
-    az ad app update --id $AzAadApp.appId --display-name $DeploymentName --identifier-uris ("https://$($DeploymentName).$($ConfigurationData.AzureRmDomain)/inbox.aspx") --password $psadCredential.Password --reply-urls $replyUrls --required-resource-accesses $requiredresourceaccesses --end-date ($(get-date).AddYears(20))
+    Write-Output "az ad app update --id $($AzAadApp.appId) --display-name $($DeploymentName) --identifier-uris $(("https://$($DeploymentName).$($ConfigurationData.AzureRmDomain)/inbox.aspx")) --password $($psadCredential.Password) --reply-urls $($replyUrls) --required-resource-accesses $($requiredresourceaccesses) --end-date $(($(get-date).AddYears(20)))"
     az ad app update --id $AzAadApp.appId --display-name $DeploymentName --identifier-uris ("https://$($DeploymentName).$($ConfigurationData.AzureRmDomain)/inbox.aspx") --password $psadCredential.Password --reply-urls $replyUrls --required-resource-accesses $requiredresourceaccesses --end-date ($(get-date).AddYears(20))
 
     if ($error) { 

--- a/V3/App-RegistrationDeployment.ps1
+++ b/V3/App-RegistrationDeployment.ps1
@@ -542,6 +542,7 @@ If(($AzAadApp = az ad app list --display-name $DeploymentName) -eq "[]") {
     $AzAadApp = $AzAadApp | ConvertFrom-Json
     $error.clear()
     az ad app update --id $AzAadApp.appId --display-name $DeploymentName --identifier-uris ("https://$($DeploymentName).$($ConfigurationData.AzureRmDomain)/inbox.aspx") --password $psadCredential.Password --reply-urls $replyUrls --required-resource-accesses $requiredresourceaccesses --end-date ($(get-date).AddYears(20))
+    az ad app update --id $AzAadApp.appId --display-name $DeploymentName --identifier-uris ("https://$($DeploymentName).$($ConfigurationData.AzureRmDomain)/inbox.aspx") --password $psadCredential.Password --reply-urls $replyUrls --required-resource-accesses $requiredresourceaccesses --end-date ($(get-date).AddYears(20))
 
     if ($error) { 
         Write-Warning "Unable to create or Update Az App, verify that account logged in has correct permissions"

--- a/V3/App-RegistrationDeployment.ps1
+++ b/V3/App-RegistrationDeployment.ps1
@@ -522,7 +522,7 @@ If ($WebApp) {
     write-output $replyUrls 
 }
 $requiredresourceaccesses = '[{"resourceAppId": "00000002-0000-0000-c000-000000000000","resourceAccess": [{"id": "311a71cc-e848-46a1-bdf8-97ff7156d8e6","type": "Scope"}]},{"resourceAppId": "00000015-0000-0000-c000-000000000000","resourceAccess": [{"id": "6397893c-2260-496b-a41d-2f1f15b16ff3","type": "Scope"},{"id": "a849e696-ce45-464a-81de-e5c5b45519c1","type": "Scope"},{"id": "ad8b4a5c-eecd-431a-a46f-33c060012ae1","type": "Scope"}]}]' | convertto-json
-If(($AzAadApp = az ad app list --display-name $DeploymentName) -eq "[]") {
+If(($AzAadApp = az ad app list --filter "displayname eq `'$DeploymentName`'") -eq "[]") {
     Write-Output "Creating new Azure AD Application"
     try {
     $ErrorActionPreference = "Continue"
@@ -551,7 +551,7 @@ If(($AzAadApp = az ad app list --display-name $DeploymentName) -eq "[]") {
         Write-Output $error
         break
     } else {
-        $AzAadApp = az ad app list --app-id $AzAadApp.appId
+        $AzAadApp = az ad app list --filter "displayname eq `'$DeploymentName`'"
     }
 }
 If ($AzAadApp) {


### PR DESCRIPTION
Fixes issue where Azure AD app is looked up by "Startswith" to "Equals"
Fixes issue when AppControlMergeFile is not in parameters.